### PR TITLE
Add Algorand address tests

### DIFF
--- a/__tests__/algorand.test.ts
+++ b/__tests__/algorand.test.ts
@@ -1,0 +1,20 @@
+import algosdk from 'algosdk';
+import { isValidAlgorandAddress } from '../lib/algorand';
+
+describe('isValidAlgorandAddress', () => {
+  it('returns true for a valid Algorand address', () => {
+    const { addr } = algosdk.generateAccount();
+    expect(isValidAlgorandAddress(addr)).toBe(true);
+  });
+
+  it('returns false for an address with an invalid checksum', () => {
+    const { addr } = algosdk.generateAccount();
+    const modified = addr.slice(0, -1) + (addr.slice(-1) === 'A' ? 'B' : 'A');
+    expect(isValidAlgorandAddress(modified)).toBe(false);
+  });
+
+  it('returns false for clearly invalid input', () => {
+    expect(isValidAlgorandAddress('notARealAddress')).toBe(false);
+    expect(isValidAlgorandAddress('')).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -55,6 +55,12 @@
     "jest-expo": "~53.0.0",
     "react-test-renderer": "18.2.0"
   },
+  "jest": {
+    "preset": "jest-expo",
+    "testMatch": [
+      "<rootDir>/__tests__/**/*.test.ts"
+    ]
+  },
    
   "overrides": {
     "react-refresh": "~0.14.0"


### PR DESCRIPTION
## Summary
- create `__tests__/algorand.test.ts`
- configure jest to look for tests in the new folder

## Testing
- `npm test -- -i` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847223f808c83339205513559d45a5e